### PR TITLE
fix(cli): oclif release command path modification

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "url": "https://github.com/rsksmart/rif-marketplace-cache.git"
   },
   "scripts": {
-    "prepack": "oclif-dev manifest",
+    "prepack": "oclif-dev manifest && sed -i '' 's#\"./src/cli\"#\"./lib/cli\"#g' package.json",
+    "postpack": "sed -i '' 's#\"./lib/cli\"#\"./src/cli\"#g' package.json",
     "bin": "tasegir run --watch ./bin/run -- ",
     "compile": "tasegir compile",
     "docs": "typedoc --mode modules --excludeNotExported --readme none --excludePrivate  --tsconfig ./node_modules/tasegir/src/config/tsconfig.json --exclude 'src/providers/*,test/**/*' --out docs src",
@@ -121,7 +122,7 @@
     "dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>"
   ],
   "oclif": {
-    "commands": "./lib/cli",
+    "commands": "./src/cli",
     "bin": "rif-marketplace-cache",
     "plugins": [
       "@oclif/plugin-help"


### PR DESCRIPTION
Oclif has specified path where to look for commands in the package.json.
In development environment it should look into the /src/ path, but for
released packages it has to be into compiled folder /lib/. There is some
magic in Oclif that should make this work, but it does not work properly
so it needs to be changed manually.

Hacky fix is replacing this value before releasing to NPM and then
returning this value after release if finished.