### PR TITLE
fix: makes domain name sha3 to hex w/o lead 0s

### DIFF
--- a/src/rns/hooks/domain-offer.hooks.ts
+++ b/src/rns/hooks/domain-offer.hooks.ts
@@ -3,7 +3,7 @@ import { disallow } from 'feathers-hooks-common'
 
 import Domain from '../models/domain.model'
 import { Op } from 'sequelize'
-import { sha3 } from 'web3-utils'
+import { sha3, numberToHex } from 'web3-utils'
 
 export default {
   before: {
@@ -42,7 +42,7 @@ export default {
                 [Op.like]: `%${$like}%`
               },
               tokenId: {
-                [Op.eq]: sha3($like)
+                [Op.eq]: numberToHex((sha3($like)))
               }
             }
           }

--- a/src/rns/hooks/domain-offer.hooks.ts
+++ b/src/rns/hooks/domain-offer.hooks.ts
@@ -42,7 +42,7 @@ export default {
                 [Op.like]: `%${$like}%`
               },
               tokenId: {
-                [Op.eq]: numberToHex((sha3($like)))
+                [Op.eq]: numberToHex(((sha3($like)) as string))
               }
             }
           }

--- a/src/rns/hooks/domain.hooks.ts
+++ b/src/rns/hooks/domain.hooks.ts
@@ -79,7 +79,7 @@ export default {
               )
               ${isOwned ? `AND "active_offers"."tokenId" IS NULL
               AND ("INACTIVE_OFFERS"."tokenId" IS NOT NULL OR "offers"."tokenId" IS NULL)` : ''}
-              ${nameFilter?.$like ? `AND "Domain"."name" LIKE '%${nameFilter.$like}%' OR "Domain"."tokenId" = '${numberToHex(sha3(nameFilter.$like))}'` : ''}
+              ${nameFilter?.$like ? `AND ("Domain"."name" LIKE '%${nameFilter.$like}%' OR "Domain"."tokenId" = '${numberToHex((sha3(nameFilter.$like)) as string)}')` : ''}
           `
 
           const sequelize = context.app.get('sequelize')

--- a/src/rns/hooks/domain.hooks.ts
+++ b/src/rns/hooks/domain.hooks.ts
@@ -1,5 +1,6 @@
 import { HookContext } from '@feathersjs/feathers'
 import { disallow } from 'feathers-hooks-common'
+import { sha3, numberToHex } from 'web3-utils'
 
 export default {
   before: {
@@ -78,7 +79,7 @@ export default {
               )
               ${isOwned ? `AND "active_offers"."tokenId" IS NULL
               AND ("INACTIVE_OFFERS"."tokenId" IS NOT NULL OR "offers"."tokenId" IS NULL)` : ''}
-              ${nameFilter?.$like ? `AND "Domain"."name" LIKE '%${nameFilter.$like}%'` : ''}
+              ${nameFilter?.$like ? `AND "Domain"."name" LIKE '%${nameFilter.$like}%' OR "Domain"."tokenId" = '${numberToHex(sha3(nameFilter.$like))}'` : ''}
           `
 
           const sequelize = context.app.get('sequelize')

--- a/src/rns/hooks/sold-domain.hooks.ts
+++ b/src/rns/hooks/sold-domain.hooks.ts
@@ -2,6 +2,8 @@ import { HookContext } from '@feathersjs/feathers'
 import { disallow } from 'feathers-hooks-common'
 
 import Domain from '../models/domain.model'
+import { Op } from 'sequelize'
+import { numberToHex, sha3 } from 'web3-utils'
 
 export default {
   before: {
@@ -22,7 +24,34 @@ export default {
         }
       }
     ],
-    find: [],
+    find: [
+      (context: HookContext) => {
+        context.params.sequelize = {
+          raw: false,
+          nest: true,
+          include: {
+            model: Domain
+          }
+        }
+        const { params: { sequelize: { include } } } = context
+        const { domain } = context.params.query as any
+
+        if (include && domain) {
+          const { name: { $like } } = domain
+          include.where = {
+            [Op.or]: {
+              name: {
+                [Op.like]: `%${$like}%`
+              },
+              tokenId: {
+                [Op.eq]: numberToHex((sha3($like)))
+              }
+            }
+          }
+        }
+
+        delete (context.params.query as any).domain
+      }],
     get: [],
     create: disallow(),
     update: disallow(),

--- a/src/rns/hooks/sold-domain.hooks.ts
+++ b/src/rns/hooks/sold-domain.hooks.ts
@@ -44,14 +44,15 @@ export default {
                 [Op.like]: `%${$like}%`
               },
               tokenId: {
-                [Op.eq]: numberToHex((sha3($like)))
+                [Op.eq]: numberToHex(((sha3($like)) as string))
               }
             }
           }
         }
 
         delete (context.params.query as any).domain
-      }],
+      }
+    ],
     get: [],
     create: disallow(),
     update: disallow(),


### PR DESCRIPTION
The rns event processor stores token ids without leading zeroes, using utility [numberToHex](https://github.com/rsksmart/rif-marketplace-cache/blob/master/src/rns/rns.processor.ts#L52).
This causes an issue when wanting to compare the sha3 of a search term (for searching domain by name) with the stored tokenIds.
For quick resolution I use the numberToHex function to create the same hex string format for the queries. This seems to be an unnecessary computation but we can fix that in the refactor.