### PR TITLE
fix: makes precache update expiration before domain table

### DIFF
--- a/src/services/rns/hooks/domain-offer.hooks.ts
+++ b/src/services/rns/hooks/domain-offer.hooks.ts
@@ -17,7 +17,7 @@ export default {
             model: Domain,
             include: {
               model: DomainExpiration,
-              attributes: ['expirationDate']
+              attributes: ['date']
             }
           }
         }
@@ -36,7 +36,7 @@ export default {
             model: Domain,
             include: {
               model: DomainExpiration,
-              attributes: ['expirationDate']
+              attributes: ['date']
             }
           }
         }

--- a/src/services/rns/hooks/domain.hooks.ts
+++ b/src/services/rns/hooks/domain.hooks.ts
@@ -1,9 +1,10 @@
 import { HookContext } from '@feathersjs/feathers'
-import { disallow, discardQuery } from 'feathers-hooks-common'
+import { disallow } from 'feathers-hooks-common'
 import { Op } from 'sequelize'
 import { numberToHex, sha3 } from 'web3-utils'
 import DomainOffer from '../models/domain-offer.model'
 import DomainExpiration from '../models/expiration.model'
+import DomainOwner from '../models/owner.model'
 
 export default {
   before: {
@@ -44,10 +45,18 @@ export default {
             include: [
               {
                 model: DomainExpiration,
-                attributes: ['expirationDate']
+                attributes: ['date']
+              },
+              {
+                model: DomainOwner,
+                attributes: ['address'],
+                where: {
+                  address: ownerAddress
+                }
               },
               {
                 model: DomainOffer,
+                attributes: placed ? ['paymentToken', 'price'] : [],
                 as: 'offers',
                 required: false
               }
@@ -55,8 +64,7 @@ export default {
             where: {
               '$offers.tokenId$': placed
                 ? { [Op.not]: null }
-                : { [Op.is]: null },
-              ownerAddress
+                : { [Op.is]: null }
             }
           }
 
@@ -74,8 +82,6 @@ export default {
               }
             }
           }
-          discardQuery('placed')
-          discardQuery('name')
         }
       }
     ],

--- a/src/services/rns/models/domain.model.ts
+++ b/src/services/rns/models/domain.model.ts
@@ -28,7 +28,7 @@ export default class Domain extends Model {
   name!: string
 
   @BelongsTo(() => DomainExpiration, {
-    foreignKey: 'tokenId'
+    foreignKey: 'id'
   })
   expiration!: DomainExpiration
 

--- a/src/services/rns/models/domain.model.ts
+++ b/src/services/rns/models/domain.model.ts
@@ -1,7 +1,8 @@
 import { Op } from 'sequelize'
-import { BelongsTo, Column, DataType, HasMany, Model, Scopes, Table } from 'sequelize-typescript'
+import { Column, DataType, HasMany, HasOne, Model, Scopes, Table } from 'sequelize-typescript'
 import DomainOffer from './domain-offer.model'
 import DomainExpiration from './expiration.model'
+import DomainOwner from './owner.model'
 import SoldDomain from './sold-domain.model'
 
 @Scopes(() => ({
@@ -10,7 +11,7 @@ import SoldDomain from './sold-domain.model'
       {
         model: DomainExpiration,
         where: {
-          expirationDate: { [Op.gt]: Date.now() }
+          date: { [Op.gt]: Date.now() }
         }
       }
     ]
@@ -22,13 +23,15 @@ export default class Domain extends Model {
   tokenId!: string
 
   @Column(DataType.STRING)
-  ownerAddress!: string
-
-  @Column(DataType.STRING)
   name!: string
 
-  @BelongsTo(() => DomainExpiration, {
-    foreignKey: 'id'
+  @HasOne(() => DomainOwner, {
+    foreignKey: 'tokenId'
+  })
+  owner!: DomainOwner
+
+  @HasOne(() => DomainExpiration, {
+    foreignKey: 'tokenId'
   })
   expiration!: DomainExpiration
 

--- a/src/services/rns/models/expiration.model.ts
+++ b/src/services/rns/models/expiration.model.ts
@@ -3,11 +3,8 @@ import { Column, DataType, Model, Table } from 'sequelize-typescript'
 @Table({ freezeTableName: true, tableName: 'rns_domain_expiration', timestamps: false })
 export default class DomainExpiration extends Model {
   @Column({ primaryKey: true, type: DataType.STRING })
-  id!: string
-
-  @Column({ type: DataType.STRING })
   tokenId!: string
 
   @Column({ type: DataType.DATE })
-  expirationDate!: number
+  date!: number
 }

--- a/src/services/rns/models/expiration.model.ts
+++ b/src/services/rns/models/expiration.model.ts
@@ -3,6 +3,9 @@ import { Column, DataType, Model, Table } from 'sequelize-typescript'
 @Table({ freezeTableName: true, tableName: 'rns_domain_expiration', timestamps: false })
 export default class DomainExpiration extends Model {
   @Column({ primaryKey: true, type: DataType.STRING })
+  id!: string
+
+  @Column({ type: DataType.STRING })
   tokenId!: string
 
   @Column({ type: DataType.DATE })

--- a/src/services/rns/models/owner.model.ts
+++ b/src/services/rns/models/owner.model.ts
@@ -1,0 +1,10 @@
+import { Column, DataType, Model, Table } from 'sequelize-typescript'
+
+@Table({ freezeTableName: true, tableName: 'rns_owner', timestamps: false })
+export default class DomainOwner extends Model {
+  @Column({ primaryKey: true, type: DataType.STRING })
+  tokenId!: string
+
+  @Column(DataType.STRING)
+  address!: string
+}

--- a/src/services/rns/rns.precache.ts
+++ b/src/services/rns/rns.precache.ts
@@ -5,6 +5,7 @@ import abiDecoder from 'abi-decoder'
 import { Logger } from '../../definitions'
 
 import Domain from './models/domain.model'
+import DomainExpiration from './models/expiration.model'
 
 abiDecoder.addABI([
   {
@@ -81,7 +82,7 @@ export async function processAuctionRegistrar (eth: Eth, logger: Logger, contrac
     const tokenId = event.returnValues.hash
     const ownerAddress = event.returnValues.owner.toLowerCase()
     const expirationDate = parseInt(event.returnValues.registrationDate) * 1000
-    const req = new Domain({ tokenId, ownerAddress, expirationDate })
-    await req.save()
+    await DomainExpiration.upsert({ tokenId, expirationDate })
+    await Domain.upsert({ tokenId, ownerAddress })
   }
 }

--- a/src/services/rns/rns.processor.ts
+++ b/src/services/rns/rns.processor.ts
@@ -18,9 +18,14 @@ async function transferHandler (logger: Logger, eventData: EventData): Promise<v
   const tokenId = Utils.numberToHex(eventData.returnValues.tokenId)
   const ownerAddress = eventData.returnValues.to.toLowerCase()
 
-  const fiftsAddr = config.get('rns.fifsAddrReg.contractAddress')
+  const fiftsAddr = config.get('rns.fifsAddrRegistrar.contractAddress')
+  const registrar = config.get('rns.registrar.contractAddress')
 
-  if ((fiftsAddr as string).toLowerCase() === ownerAddress) {
+  if (ownerAddress === (fiftsAddr as string).toLowerCase()) {
+    return
+  }
+
+  if (ownerAddress === (registrar as string).toLowerCase()) {
     return
   }
 


### PR DESCRIPTION
adds id to expiration table definition

As I had a different version of the ui-config that was generated by the dev project, I was missing the auction registrar address and thus did not capture the error in my last PR.
This is to fix the issue with foreign key constraints when writing to domains table.