### PR TITLE
fix(core): confirmations are handled for multiple blocks

### DIFF
--- a/src/blockchain/confirmator.ts
+++ b/src/blockchain/confirmator.ts
@@ -12,7 +12,7 @@ import type { EventEmitter } from 'events'
 import { literal, Op } from 'sequelize'
 
 function isConfirmedClosure (currentBlockNumber: number) {
-  return (event: Event): boolean => event.getConfirmationsCount(currentBlockNumber) === event.targetConfirmation
+  return (event: Event): boolean => event.getConfirmationsCount(currentBlockNumber) >= event.targetConfirmation
 }
 
 const NEW_EVENT_EVENT_NAME = 'newEvent'


### PR DESCRIPTION
If there are processed mutiple blocks in one confirmation invokation
some events could be skipped over.