### PR TITLE
Fix: Precache fixes for testnet

### DIFF
--- a/config/rsktestnet.json5
+++ b/config/rsktestnet.json5
@@ -6,25 +6,30 @@
     owner: {
       contractAddress: "0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71",
       eventsEmitter: {
+        startingBlock: 385433,
         confirmations: 3
       }
     },
     reverse: {
       contractAddress: "0x8587385ad60038bB181aFfDF687c4D1B80C4787e",
       eventsEmitter: {
+        startingBlock: 419976,
         confirmations: 3
       }
     },
     placement: {
       contractAddress: "0xe93EE0Ac6C97807F4c28f66cA44E1Ad18E485033",
       eventsEmitter: {
+        startingBlock: 829200,
         confirmations: 3
       }
     },
     registrar: {
+      startingBlock: 385324,
       contractAddress: "0x3d1a11c623bd21375f2b69f4eec814f4ceeb1d8d"
     },
     fifsAddrRegistrar: {
+      startingBlock: 385324,
       contractAddress: "0x90734bd6bf96250a7b262e2bc34284b0d47c1e8d"
     }
   }

--- a/src/services/rns/models/transfer.model.ts
+++ b/src/services/rns/models/transfer.model.ts
@@ -5,7 +5,7 @@ export default class Transfer extends Model {
   @Column({ primaryKey: true, type: DataType.STRING })
   id!: string
 
-  @Column(DataType.STRING)
+  @Column({ primaryKey: true, type: DataType.STRING })
   tokenId!: string
 
   @Column(DataType.STRING)

--- a/src/services/rns/rns.processor.ts
+++ b/src/services/rns/rns.processor.ts
@@ -33,8 +33,13 @@ async function transferHandler (logger: Logger, eventData: EventData, eth: Eth, 
       const name = Utils.hexToAscii('0x' + decodedData.params[2].value.slice(218, decodedData.params[2].value.length))
 
       if (name) {
-        await Domain.upsert({ tokenId, name: `${name}.${tld}` })
-
+        try {
+          await Domain.upsert({ tokenId, name: `${name}.${tld}` })
+        } catch(e) {
+          await Domain.upsert({ tokenId })
+          logger.warn(`Domain name ${name}.${tld} for token ${tokenId} could not be stored.`)
+        }
+  
         if (domainsService.emit) {
           domainsService.emit('patched', { tokenId })
         }


### PR DESCRIPTION
* Implements required fixes that came up during Testnet Trials

- Add a `try/catch` statement in the Processor when storing names that cannot be parsed correctly (same fix was incorporated to the `precache` in previous PR but was missing this line).
- Add `tokenId` as part of the composed PK of the `Transfer` model. This is to cover a valid situation for batch RNS Processing in which you can have multiple tokens transferred in the same tx. 
- Setup starting blocks in the `rsktestnet.json5` config files to significantly reduce the time for the Precache to Run.
- Fix for Reorgs - TBD
