### PR TITLE
chore(rns): bump version for RNS contract

### DIFF
--- a/config/rsktestnet.json5
+++ b/config/rsktestnet.json5
@@ -18,9 +18,9 @@
       }
     },
     placement: {
-      contractAddress: "0xe93EE0Ac6C97807F4c28f66cA44E1Ad18E485033",
+      contractAddress: "0x5a2E616F64923AeF99E871EE6F80b9A00CCD6316",
       eventsEmitter: {
-        startingBlock: 829200,
+        startingBlock: 992176,
         confirmations: 3
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-marketplace-cache",
-  "version": "0.1.0-dev.2",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2498,6 +2498,11 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.1.tgz",
       "integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
     },
+    "@openzeppelin/contracts-ethereum-package": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
+      "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
+    },
     "@openzeppelin/upgrades": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades/-/upgrades-2.8.0.tgz",
@@ -2811,11 +2816,13 @@
       }
     },
     "@rsksmart/rif-marketplace-nfts": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-marketplace-nfts/-/rif-marketplace-nfts-0.0.2.tgz",
-      "integrity": "sha512-ij/CRGi8MWlX1RDC5MPF5970ONxORzvqyPc4evGP+RugG+y1Apiifddp/XoBEG8HwO9TnBCRi2EWauccXmxklQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-marketplace-nfts/-/rif-marketplace-nfts-0.1.1.tgz",
+      "integrity": "sha512-rkTQQ7WmrK+Csvf5/htGFwZ23k0HOdVCrawcvhS0QUME8UWoQk0xql8W4y3t3SPrOYJ6pMPl3mbIntKbEXhDBA==",
       "requires": {
         "@openzeppelin/contracts": "^2.5.0",
+        "@openzeppelin/contracts-ethereum-package": "^2.2.3",
+        "@openzeppelin/upgrades": "^2.8.0",
         "@rsksmart/erc677": "^1.0.1",
         "solidity-bytes-utils": "0.0.8"
       }
@@ -10293,17 +10300,17 @@
       }
     },
     "ethereumjs-wallet": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz",
-      "integrity": "sha512-qiXPiZOsStem+Dj/CQHbn5qex+FVkuPmGH7SvSnA9F3tdRDt8dLMyvIj3+U05QzVZNPYh4HXEdnzoYI4dZkr9w==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.4.tgz",
+      "integrity": "sha512-xAYLWVH/MA9Ds1+BiDTfdRrCBQIz7r70EJSjuBnvw/x40qJ1jBoBBAp8/l+I9VPGAsUXvHTfcnp2OZ9LbcTs/g==",
       "requires": {
         "aes-js": "^3.1.1",
         "bs58check": "^2.1.2",
         "ethereumjs-util": "^6.0.0",
-        "hdkey": "^1.1.0",
+        "hdkey": "^1.1.1",
         "randombytes": "^2.0.6",
         "safe-buffer": "^5.1.2",
-        "scrypt.js": "^0.3.0",
+        "scryptsy": "^1.2.1",
         "utf8": "^3.0.0",
         "uuid": "^3.3.2"
       }
@@ -13777,9 +13784,9 @@
       }
     },
     "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -19935,15 +19942,6 @@
         "ajv-keywords": "^3.4.1"
       }
     },
-    "scrypt": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.0.8"
-      }
-    },
     "scrypt-js": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
@@ -19967,15 +19965,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
-      }
-    },
-    "scrypt.js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
-      "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
-      "requires": {
-        "scrypt": "^6.0.2",
-        "scryptsy": "^1.2.1"
       }
     },
     "scryptsy": {
@@ -26805,9 +26794,9 @@
       "dev": true
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
+      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@oclif/errors": "^1.2.2",
     "@oclif/parser": "^3.8.5",
     "@oclif/plugin-help": "^3.0.1",
-    "@rsksmart/rif-marketplace-nfts": "~0.0.2",
+    "@rsksmart/rif-marketplace-nfts": "~0.1.1",
     "@rsksmart/rif-marketplace-storage": "^0.1.0-dev.0",
     "@rsksmart/rns-auction-registrar": "1.0.2",
     "@rsksmart/rns-reverse": "^1.0.2",

--- a/src/services/rns/index.ts
+++ b/src/services/rns/index.ts
@@ -1,4 +1,4 @@
-import simplePlacementsContractAbi from '@rsksmart/rif-marketplace-nfts/ERC721SimplePlacementsABI.json'
+import simplePlacementsContractAbi from '@rsksmart/rif-marketplace-nfts/ERC721SimplePlacementsV1Data.json'
 import auctionRegistrarContractAbi from '@rsksmart/rns-auction-registrar/TokenRegistrarData.json'
 import rnsReverseContractAbi from '@rsksmart/rns-reverse/NameResolverData.json'
 import rnsContractAbi from '@rsksmart/rns-rskregistrar/RSKOwnerData.json'
@@ -62,7 +62,7 @@ async function precache (eth?: Eth): Promise<void> {
 
   await fetchEventsForService(eth, 'rns.owner', rnsContractAbi.abi as AbiItem[], dataQueuePusher)
   await fetchEventsForService(eth, 'rns.reverse', rnsReverseContractAbi.abi as AbiItem[], dataQueuePusher)
-  await fetchEventsForService(eth, 'rns.placement', simplePlacementsContractAbi as AbiItem[], dataQueuePusher)
+  await fetchEventsForService(eth, 'rns.placement', simplePlacementsContractAbi.abi as AbiItem[], dataQueuePusher)
 
   // We need to sort the events in order to have valid sequence of Events
   eventsDataQueue.sort((a, b): number => {
@@ -137,7 +137,7 @@ const rns: CachedService = {
     rnsReverseEventsEmitter.on('newConfirmation', (data) => confirmationService.emit('newConfirmation', data))
     rnsReverseEventsEmitter.on('invalidConfirmation', (data) => confirmationService.emit('invalidConfirmation', data))
 
-    const rnsPlacementsEventsEmitter = getEventsEmitterForService('rns.placement', eth, simplePlacementsContractAbi as AbiItem[])
+    const rnsPlacementsEventsEmitter = getEventsEmitterForService('rns.placement', eth, simplePlacementsContractAbi.abi as AbiItem[])
     rnsPlacementsEventsEmitter.on('newEvent', errorHandler(eventProcessor(loggingFactory('rns.placement:processor'), eth, services), logger))
     rnsPlacementsEventsEmitter.on('error', (e: Error) => {
       logger.error(`There was unknown error in Events Emitter for rns.placement! ${e}`)


### PR DESCRIPTION
* Use the new version of the NFTS contract (`0.1.1`). This requires to change the way the `ABI` is processed (now matches all the other contracts). 
* Also updated the Testnet address for the contract using the new deployed address.

Closes #203 