### PR TITLE
feat(core): support listening on topics

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -43,8 +43,17 @@
     // Sets if Storage service should be enabled
     enabled: true,
 
-    // Events that will be listened to
-    events: ['TotalCapacitySet', 'MessageEmitted', 'BillingPlanSet', 'NewAgreement', 'AgreementFundsDeposited', 'AgreementFundsWithdrawn', 'AgreementFundsPayout', 'AgreementStopped'],
+    // Topics that will be listened to
+    topics: [
+      'TotalCapacitySet(address,uin128)',
+      'BillingPlanSet(address,uint64,uint64)',
+      'MessageEmitted(address,bytes32[])',
+      'NewAgreement(bytes32,bytes32[],address,address,uint128,uint64,uint64,uint256)',
+      'AgreementFundsDeposited(bytes32,uint256)',
+      'AgreementFundsWithdrawn(bytes32,uint256)',
+      'AgreementFundsPayout(bytes32,uint256)',
+      'AgreementStopped(bytes32)',
+    ],
 
     // Specify behavior of EventsEmitter, that retrieves events from blockchain and pass them onwards for further processing.
     eventsEmitter: {

--- a/src/blockchain/utils.ts
+++ b/src/blockchain/utils.ts
@@ -1,4 +1,4 @@
-import { AbiItem } from 'web3-utils'
+import { AbiItem, keccak256 } from 'web3-utils'
 import Eth from 'web3-eth'
 import { EventEmitter } from 'events'
 import config from 'config'
@@ -15,6 +15,11 @@ function getBlockTracker (keyPrefix?: string): BlockTracker {
   return new BlockTracker(store)
 }
 
+function hashTopics (topics?: string[]): string[] {
+  if (!topics) return []
+  return topics.map(e => keccak256(e))
+}
+
 export async function getBlockDate (eth: Eth, blockNumber: number): Promise<Date> {
   return new Date(((await eth.getBlock(blockNumber)).timestamp as number) * 1000)
 }
@@ -29,8 +34,10 @@ export function getEventsEmitterForService (serviceName: string, eth: Eth, contr
   const contract = new eth.Contract(contractAbi, contractAddresses)
   const logger = loggingFactory(`${serviceName}:blockchain`)
 
-  const eventsToListen = config.get<string[]>(`${serviceName}.events`)
-  logger.info(`For listening on service '${serviceName}' for events ${eventsToListen.join(', ')} using contract on address: ${contractAddresses}`)
+  const eventsToListen = config.has(`${serviceName}.events`) ? config.get<string[]>(`${serviceName}.events`) : undefined
+  const topicsToListen = config.has(`${serviceName}.topics`) ? config.get<string[]>(`${serviceName}.topics`) : undefined
+
+  logger.info(`For listening on service '${serviceName}' using contract on address: ${contractAddresses}`)
   const eventsEmitterOptions = config.get<EventsEmitterOptions>(`${serviceName}.eventsEmitter`)
   const newBlockEmitterOptions = config.get<NewBlockEmitterOptions>(`${serviceName}.newBlockEmitter`)
   const options = Object.assign(
@@ -43,7 +50,9 @@ export function getEventsEmitterForService (serviceName: string, eth: Eth, contr
     } as EventsEmitterOptions
   )
 
-  return eventsEmitterFactory(eth, contract, eventsToListen, options)
+  // The topics has to be nested because that represents "or" operation between the topics and not "and".
+  // https://eth.wiki/json-rpc/API#parameters-45
+  return eventsEmitterFactory(eth, contract, eventsToListen, [hashTopics(topicsToListen)], options)
 }
 
 export function getNewBlockEmitter (eth: Eth): AutoStartStopEventEmitter {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -94,6 +94,9 @@ export interface BlockchainServiceOptions {
   // Address of deployed  contract
   contractAddress?: string
 
+  // Topics that will be listened to, if specified than has priority over "events" configuration
+  topics?: string[]
+
   // Events that will be listened to
   events?: string[]
 

--- a/test/blockchain/events.spec.ts
+++ b/test/blockchain/events.spec.ts
@@ -37,7 +37,7 @@ const DATA_EVENT_NAME = 'newEvent'
  * Dummy implementation for testing BaseEventsEmitter
  */
 export class DummyEventsEmitter extends BaseEventsEmitter {
-  constructor (eth: Eth, contract: Contract, events: string[], options?: EventsEmitterOptions, name?: string) {
+  constructor (eth: Eth, contract: Contract, events: string[], topics?: string[], options?: EventsEmitterOptions, name?: string) {
     let logger: Logger
 
     if (!name) {
@@ -46,7 +46,7 @@ export class DummyEventsEmitter extends BaseEventsEmitter {
       logger = loggingFactory('blockchain:events:' + name)
     }
 
-    super(eth, contract, events, logger, options)
+    super(eth, contract, logger, events, options)
   }
 
   async createEvent (data: EventData | EventData[]): Promise<void> {
@@ -97,7 +97,7 @@ describe('BaseEventsEmitter', () => {
     const newBlockEmitter = new EventEmitter()
     const options = { blockTracker, newBlockEmitter }
     const spy = sinon.spy()
-    const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], options)
+    const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], undefined, options)
     eventsEmitter.on(DATA_EVENT_NAME, spy) // Will start processingPastEvents() which will be delayed
 
     // Directly calling processEvents(), which should be blocked by the processingPastEvents()
@@ -131,7 +131,7 @@ describe('BaseEventsEmitter', () => {
       const newBlockEmitter = new EventEmitter()
       const options: EventsEmitterOptions = { confirmations: 2, blockTracker, newBlockEmitter }
       const spy = sinon.spy()
-      const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], options)
+      const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], undefined, options)
       eventsEmitter.on(DATA_EVENT_NAME, spy)
       await sleep(100)
 
@@ -154,7 +154,7 @@ describe('BaseEventsEmitter', () => {
       const newBlockEmitter = new EventEmitter()
       const options: EventsEmitterOptions = { confirmations: 2, blockTracker, newBlockEmitter }
       const spy = sinon.spy()
-      const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], options)
+      const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], undefined, options)
       eventsEmitter.on(DATA_EVENT_NAME, spy)
 
       const events = [
@@ -191,7 +191,7 @@ describe('BaseEventsEmitter', () => {
       const newBlockEmitter = new EventEmitter()
       const options = { blockTracker, newBlockEmitter }
       const spy = sinon.spy()
-      const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], options)
+      const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], undefined, options)
       eventsEmitter.on(DATA_EVENT_NAME, spy)
       await sleep(100)
 
@@ -212,7 +212,7 @@ describe('BaseEventsEmitter', () => {
       const newBlockEmitter = new EventEmitter()
       const options = { blockTracker, newBlockEmitter }
       const spy = sinon.spy()
-      const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], options)
+      const eventsEmitter = new DummyEventsEmitter(eth, contract, ['testEvent'], undefined, options)
 
       const testEvent = eventMock()
       const events = [
@@ -260,7 +260,7 @@ describe('PollingEventsEmitter', function () {
     const newEventSpy = sinon.spy()
     const reorgSpy = sinon.spy()
     const reorgOutOfRangeSpy = sinon.spy()
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], options)
+    const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], undefined, options)
     eventsEmitter.on(DATA_EVENT_NAME, newEventSpy)
     eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
     eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
@@ -298,7 +298,7 @@ describe('PollingEventsEmitter', function () {
     const newEventSpy = sinon.spy()
     const reorgSpy = sinon.spy()
     const reorgOutOfRangeSpy = sinon.spy()
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], options)
+    const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], undefined, options)
     eventsEmitter.on(DATA_EVENT_NAME, newEventSpy)
     eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
     eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
@@ -332,7 +332,7 @@ describe('PollingEventsEmitter', function () {
     const newEventSpy = sinon.spy()
     const reorgSpy = sinon.spy()
     const reorgOutOfRangeSpy = sinon.spy()
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], options)
+    const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], undefined, options)
     eventsEmitter.on(DATA_EVENT_NAME, newEventSpy)
     eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
     eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
@@ -369,7 +369,7 @@ describe('PollingEventsEmitter', function () {
     const newBlockEmitter = new EventEmitter()
     const options = { blockTracker, newBlockEmitter }
     const spy = sinon.spy()
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], options)
+    const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], undefined, options)
     eventsEmitter.on(DATA_EVENT_NAME, spy) // Will start processingPastEvents() which will be delayed
 
     // Directly calling processEvents(), which should be blocked by the processingPastEvents()
@@ -432,7 +432,7 @@ describe('PollingEventsEmitter', function () {
       const newEventSpy = sinon.spy()
       const reorgSpy = sinon.spy()
       const reorgOutOfRangeSpy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], options)
+      const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], undefined, options)
       eventsEmitter.on(DATA_EVENT_NAME, newEventSpy)
       eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
       eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
@@ -470,7 +470,7 @@ describe('PollingEventsEmitter', function () {
       const newEventSpy = sinon.spy()
       const reorgSpy = sinon.spy()
       const reorgOutOfRangeSpy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], options)
+      const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], undefined, options)
       eventsEmitter.on(DATA_EVENT_NAME, newEventSpy)
       eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
       eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
@@ -508,7 +508,7 @@ describe('PollingEventsEmitter', function () {
       const newEventSpy = sinon.spy()
       const reorgSpy = sinon.spy()
       const reorgOutOfRangeSpy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], options)
+      const eventsEmitter = new PollingEventsEmitter(eth, contract, ['testEvent'], undefined, options)
       eventsEmitter.on(DATA_EVENT_NAME, newEventSpy)
       eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
       eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)


### PR DESCRIPTION
Adds support for listening topics, which will filter only those events from contract that we are interested in. If the Contract emits other events that we are not interested then they will be ignored directly by the blockchain node and won't be even fetched to Cache.