### PR TITLE
feat: batch support for domain registration

### DIFF
--- a/config/ganache.json5
+++ b/config/ganache.json5
@@ -8,6 +8,7 @@
   },
   rns: {
     enabled: true,
+    batchContractAddress: "0xc0b3B62DD0400E4baa721DdEc9B8A384147b23fF",
     owner: {
       contractAddress: "0x4bf749ec68270027C5910220CEAB30Cc284c7BA2",
       eventsEmitter: {

--- a/config/rskmainnet.json5
+++ b/config/rskmainnet.json5
@@ -1,8 +1,13 @@
 {
+  port: 3030,
+  blockchain: {
+    provider: "http://127.0.0.1:7777/"
+  },
   storage: {
     enabled: false,
   },
   rns: {
+    batchContractAddress: "0x2beb2819e110b34c802c761e737470760af2057f",
     owner: {
       contractAddress: "0x45d3e4fb311982a06ba52359d44cb4f5980e0ef1",
       eventsEmitter: {

--- a/config/rskmainnet.json5
+++ b/config/rskmainnet.json5
@@ -1,8 +1,4 @@
 {
-  port: 3030,
-  blockchain: {
-    provider: "http://127.0.0.1:7777/"
-  },
   storage: {
     enabled: false,
   },

--- a/config/rsktestnet.json5
+++ b/config/rsktestnet.json5
@@ -1,8 +1,13 @@
 {
+  port: 3030,
+  blockchain: {
+    provider: "http://127.0.0.1:7777/"
+  },
   storage: {
     enabled: false,
   },
   rns: {
+    batchContractAddress: "0x380a47e2a1cec8a21cf00374ea5d092166a702fc",
     owner: {
       contractAddress: "0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71",
       eventsEmitter: {

--- a/config/rsktestnet.json5
+++ b/config/rsktestnet.json5
@@ -1,8 +1,4 @@
 {
-  port: 3030,
-  blockchain: {
-    provider: "http://127.0.0.1:7777/"
-  },
   storage: {
     enabled: false,
   },

--- a/config/test.json5
+++ b/config/test.json5
@@ -6,6 +6,7 @@
   },
   rns: {
     enabled: true,
+    batchContractAddress: "BATCH_ADDR",
     owner: {
       contractAddress: "OWNER_ADDR"
     },

--- a/config/test.json5
+++ b/config/test.json5
@@ -6,7 +6,7 @@
   },
   rns: {
     enabled: true,
-    batchContractAddress: "BATCH_ADDR",
+    batchContractAddress: "0xc0b3b62dd0400e4baa721ddec9b8a384147b23ff", // encoded address used in tests
     owner: {
       contractAddress: "OWNER_ADDR"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-marketplace-cache",
-  "version": "0.3.0",
+  "version": "1.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "pg": "^8.2.1",
     "pg-hstore": "^2.3.3",
     "reflect-metadata": "^0.1.13",
+    "rlp": "^2.2.6",
     "sequelize": "^5.21.10",
     "sequelize-store": "^0.3.1",
     "sequelize-typescript": "^1.1.0",

--- a/src/blockchain/utils.ts
+++ b/src/blockchain/utils.ts
@@ -9,6 +9,8 @@ import eventsEmitterFactory, { EventsEmitterOptions } from './events'
 import { NewBlockEmitterOptions } from '../definitions'
 import { BlockTracker } from './block-tracker'
 
+export type RLPDecoded = Array<Array<number[]>>
+
 function getBlockTracker (keyPrefix?: string): BlockTracker {
   const store = getObject(keyPrefix)
   return new BlockTracker(store)

--- a/src/blockchain/utils.ts
+++ b/src/blockchain/utils.ts
@@ -9,8 +9,6 @@ import eventsEmitterFactory, { EventsEmitterOptions } from './events'
 import { NewBlockEmitterOptions } from '../definitions'
 import { BlockTracker } from './block-tracker'
 
-export type RLPDecoded = Array<Array<number[]>>
-
 function getBlockTracker (keyPrefix?: string): BlockTracker {
   const store = getObject(keyPrefix)
   return new BlockTracker(store)

--- a/test/services/rns/processor.spec.ts
+++ b/test/services/rns/processor.spec.ts
@@ -255,7 +255,7 @@ describe('Domain events', () => {
       '00000000000000000000000000000000000000000000000001646f6d61696e6f74686572000000000000000000' +
       '0000000000'
 
-    const mockedTransaction = transactionMock(transactionHash, txInput, {})
+    const mockedTransaction = transactionMock(transactionHash, txInput)
     eth.getTransaction(transactionHash).resolves(mockedTransaction)
 
     const event = eventMock({

--- a/test/services/rns/processor.spec.ts
+++ b/test/services/rns/processor.spec.ts
@@ -244,7 +244,7 @@ describe('Domain events', () => {
   })
 
   it('should Decode Name for new Domain - Batch', async () => {
-    // Encoded multiple registrations for  `domain.rsk` and `domainother.rsk`ß
+    // Encoded multiple registrations for  `domain.rsk` and `domainother.rsk`
     const txInput = '0x4000aea0000000000000000000000000c0b3b62dd0400e4baa721ddec9b8a384147b23ff' +
       '0000000000000000000000000000000000000000000000003782dace9d90000000000000000000000000000000' +
       '000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000' +

--- a/test/services/rns/processor.spec.ts
+++ b/test/services/rns/processor.spec.ts
@@ -20,7 +20,7 @@ import DomainExpiration from '../../../src/services/rns/models/expiration.model'
 import DomainOffer from '../../../src/services/rns/models/domain-offer.model'
 import SoldDomain from '../../../src/services/rns/models/sold-domain.model'
 
-import { eventMock } from '../../utils'
+import { eventMock, transactionMock } from '../../utils'
 
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
@@ -39,10 +39,15 @@ describe('Domain events', () => {
   const label = 'domain'
   const name = 'domain.rsk'
   const tokenId = Utils.sha3(label) as string
+  const labelOther = 'domainother'
+  const nameOther = 'domainother.rsk'
+  const tokenOtherId = Utils.sha3(labelOther) as string
   const from = 'from_addr'
   const to = 'to_addr'
   const other = 'other_addr'
   const expirationTime = (new Date()).getTime().toString()
+  const zeroAddress = '0x0000000000000000000000000000000000000000'
+  const transactionHash = 'TX_HASH'
 
   before(() => {
     sequelize = sequelizeFactory()
@@ -78,7 +83,7 @@ describe('Domain events', () => {
   it('should update Domain Owner on Tranfer', async () => {
     const event = eventMock({
       event: 'Transfer',
-      transactionHash: 'TX_HASH',
+      transactionHash,
       returnValues: { tokenId, from, to }
     })
 
@@ -100,12 +105,12 @@ describe('Domain events', () => {
   it('should handle multiple Transfers in the same transaction', async () => {
     const event = eventMock({
       event: 'Transfer',
-      transactionHash: 'TX_HASH',
+      transactionHash,
       returnValues: { tokenId, from, to }
     })
     const newEvent = eventMock({
       event: 'Transfer',
-      transactionHash: 'TX_HASH',
+      transactionHash,
       returnValues: { tokenId, from: to, to: other }
     })
 
@@ -236,6 +241,50 @@ describe('Domain events', () => {
 
     expect(createdEvent).to.be.instanceOf(Domain)
     expect(createdEvent?.name).to.be.eql(event.returnValues.name)
+  })
+
+  it('should Decode Name for new Domain - Batch', async () => {
+    // Encoded multiple registrations for  `domain.rsk` and `domainother.rsk`ß
+    const txInput = '0x4000aea0000000000000000000000000c0b3b62dd0400e4baa721ddec9b8a384147b23ff' +
+      '0000000000000000000000000000000000000000000000003782dace9d90000000000000000000000000000000' +
+      '000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000' +
+      '0000000000d2f8d0881bc16d674ec80000f8c5b85ec2c414c890f8bf6a479f320ead074411a4b0e7944ea8c9c1' +
+      '6d97ebe8ec0de1264229e19b6681ec254dfdb4ee52ed336e6a58d6a635bba4dd00000000000000000000000000' +
+      '00000000000000000000000000000000000001646f6d61696eb863c2c414c890f8bf6a479f320ead074411a4b0' +
+      'e7944ea8c9c17a134ff0de2189b133a610ff8e4a0164c1fd91a7bb3c4052b1fb1bb6792a220800000000000000' +
+      '00000000000000000000000000000000000000000000000001646f6d61696e6f74686572000000000000000000' +
+      '0000000000'
+
+    const mockedTransaction = transactionMock(transactionHash, txInput, {})
+    eth.getTransaction(transactionHash).resolves(mockedTransaction)
+
+    const event = eventMock({
+      event: 'Transfer',
+      transactionHash,
+      returnValues: { tokenId, from: zeroAddress, to: to }
+    })
+
+    const newEvent = eventMock({
+      event: 'Transfer',
+      transactionHash,
+      returnValues: { tokenId: tokenOtherId, from: zeroAddress, to: to }
+    })
+
+    await processor(event)
+
+    const createdEvent = await Domain.findByPk(Utils.numberToHex(tokenId))
+
+    expect(createdEvent).to.be.instanceOf(Domain)
+    expect(createdEvent?.name).to.be.eql(name)
+    expect(domainServiceEmitSpy).to.have.been.calledWith('patched')
+
+    await processor(newEvent)
+
+    const newCreatedEvent = await Domain.findByPk(Utils.numberToHex(tokenOtherId))
+
+    expect(newCreatedEvent).to.be.instanceOf(Domain)
+    expect(newCreatedEvent?.name).to.be.eql(nameOther)
+    expect(domainServiceEmitSpy).to.have.been.calledWith('patched')
   })
 })
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,4 @@
-import { BlockHeader, BlockTransactionString, TransactionReceipt } from 'web3-eth'
+import { BlockHeader, BlockTransactionString, TransactionReceipt, Transaction } from 'web3-eth'
 import { Substitute } from '@fluffy-spoon/substitute'
 import { EventData } from 'web3-eth-contract'
 
@@ -69,4 +69,17 @@ export function blockMock (blockNumber: number, blockHash = '0x123', options: Pa
   block.number.returns!(blockNumber)
   block.hash.returns!(blockHash)
   return block
+}
+
+export function transactionMock (hash: string, input: string, options: Partial<Transaction> = {}): Transaction {
+  const transaction = Substitute.for<Transaction>()
+
+  Object.entries(options).forEach(([key, value]) => {
+    // @ts-ignore
+    transaction[key].returns!(value)
+  })
+
+  transaction.hash.returns!(hash)
+  transaction.input.returns!(input)
+  return transaction
 }


### PR DESCRIPTION
* Decode domain names when processed in Batch. This requires processing the internal transactions of the TX data field, using RLP and following the `FifsRegistrar` encoding.)
* Add support and configuration for the RNS Batch Registration contract (in all environments).
* Test for transaction decoding in Batch Mode (Registering two domains).
