### PR TITLE
fix: return total staked fiat as 0.00 for empty account

### DIFF
--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -44,9 +44,9 @@ export class StakeService extends Service {
     const sequelize = this.Model.sequelize
 
     const query = getStakesForAccount(sequelize, account)
-    const [{ totalStakedFiat }] = await sequelize.query(query, { type: QueryTypes.SELECT, raw: true })
+    const [{ totalStakedFiat }] = (await sequelize.query(query, { type: QueryTypes.SELECT, raw: true }))
     return {
-      totalStakedFiat: new BigNumber(totalStakedFiat).toFixed(2),
+      totalStakedFiat: new BigNumber(totalStakedFiat || 0).toFixed(2),
       stakes: await StakeModel.findAll({ where: { account } })
     }
   }

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -44,7 +44,7 @@ export class StakeService extends Service {
     const sequelize = this.Model.sequelize
 
     const query = getStakesForAccount(sequelize, account)
-    const [{ totalStakedFiat }] = (await sequelize.query(query, { type: QueryTypes.SELECT, raw: true }))
+    const [{ totalStakedFiat }] = await sequelize.query(query, { type: QueryTypes.SELECT, raw: true })
     return {
       totalStakedFiat: new BigNumber(totalStakedFiat || 0).toFixed(2),
       stakes: await StakeModel.findAll({ where: { account } })

--- a/test/integration/services/storage/storage-manger.spec.ts
+++ b/test/integration/services/storage/storage-manger.spec.ts
@@ -311,6 +311,17 @@ describe('Storage service', function () {
         expect(totalStakedUSD).to.be.eql(totalStakedFiat)
         expect(stakes.length).to.be.eql(1)
       })
+      it('should return total staked fiat equal to 0.00 for empty account', async () => {
+        const client = getFeatherClient()
+        const stakeService = client.service(ServiceAddresses.STORAGE_STAKES)
+
+        const account = app.getRandomAccount()
+        const { totalStakedFiat, stakes } = await stakeService.get(account)
+        const totalStakedUSD = '0.00'
+
+        expect(totalStakedUSD).to.be.eql(totalStakedFiat)
+        expect(stakes.length).to.be.eql(0)
+      })
     })
     describe('Avg Billing Plan', () => {
       before(async () => {


### PR DESCRIPTION
Solves the problem of returning "NaN" when trying to get the stakes for an account without funds