### PR TITLE
fix: add comms configuration for ganache

### DIFF
--- a/config/ganache.json5
+++ b/config/ganache.json5
@@ -51,5 +51,16 @@
         confirmations: 2
       }
     }
+  },
+  comms: {
+    libp2p: {
+      config: {
+        peerDiscovery: {
+          bootstrap: {
+            enabled: false
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
* Overrides comms bootstrap setting to be able to run Cache in local mode, using `ganache`.