### PR TITLE
fix(storage): makes periodsSinceLastPayout 0 if not positive

### DIFF
--- a/src/services/storage/models/agreement.model.ts
+++ b/src/services/storage/models/agreement.model.ts
@@ -57,7 +57,11 @@ export default class Agreement extends Model {
     // Date.now = ms
     // this.lastPayout.getTime = ms
     // this.billingPeriod = seconds ==> * 1000
-    const timePassedMs = Math.max(Date.now() - this.lastPayout.getTime(), 0)
+    const timePassedMs = Date.now() - this.lastPayout.getTime()
+    if (timePassedMs < 0) {
+      // We cannot fully rely on blockchain time, as it can be a little bit ahead of real time
+      return new BigNumber(0)
+    }
     const periods = new BigNumber(timePassedMs).div(this.billingPeriod.times(1000))
     return floor
       ? bnFloor(periods)

--- a/src/services/storage/models/agreement.model.ts
+++ b/src/services/storage/models/agreement.model.ts
@@ -57,7 +57,8 @@ export default class Agreement extends Model {
     // Date.now = ms
     // this.lastPayout.getTime = ms
     // this.billingPeriod = seconds ==> * 1000
-    const periods = new BigNumber(Date.now() - this.lastPayout.getTime()).div(this.billingPeriod.times(1000))
+    const timePassedMs = Math.max(Date.now() - this.lastPayout.getTime(), 0)
+    const periods = new BigNumber(timePassedMs).div(this.billingPeriod.times(1000))
     return floor
       ? bnFloor(periods)
       : periods

--- a/src/services/storage/models/agreement.model.ts
+++ b/src/services/storage/models/agreement.model.ts
@@ -58,10 +58,12 @@ export default class Agreement extends Model {
     // this.lastPayout.getTime = ms
     // this.billingPeriod = seconds ==> * 1000
     const timePassedMs = Date.now() - this.lastPayout.getTime()
+
     if (timePassedMs < 0) {
       // We cannot fully rely on blockchain time, as it can be a little bit ahead of real time
       return new BigNumber(0)
     }
+
     const periods = new BigNumber(timePassedMs).div(this.billingPeriod.times(1000))
     return floor
       ? bnFloor(periods)


### PR DESCRIPTION
It seems that `lastPayout.getTime()` is 5 minutes ahead of `Date.now()`. This fix defaults to 0 when that time is bigger than now