### PR TITLE
chore: block number for staking contract

### DIFF
--- a/config/staging.json5
+++ b/config/staging.json5
@@ -14,7 +14,7 @@
     staking: {
       contractAddress: "0xB45BbC3B983E9d60c131F177831e911043a36b6f",
       eventsEmitter: {
-        startingBlock: 133904,
+        startingBlock: 1333904,
         confirmations: 3
       }
     },


### PR DESCRIPTION
* Updates correct block number for `staking` contract in Staging.