### PR TITLE
chore: adds tokens in ganache config

### DIFF
--- a/config/ganache.json5
+++ b/config/ganache.json5
@@ -6,6 +6,9 @@
   },
   storage: {
     enabled: true,
+    tokens: {
+      '0x67B5656d60a809915323Bf2C40A8bEF15A152e3e': 'rif'
+    },
     storageManager: {
       contractAddress: "0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E",
       eventsEmitter: {


### PR DESCRIPTION
* Add `RIF` token configuration which is used in `ganache` and deployed correctly by DEV project.