### PR TITLE
fix(core): logs colors handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,6 @@ coverage
 lib
 node_modules
 test
+types
+*.sqlite
+db-backups

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY config ./config/
 RUN sed -i 's#"./src/cli"#"./lib/cli"#g' package.json
 
 EXPOSE 3030
+ENV LOG_NO_COLORS 'true'
 
 ENTRYPOINT [ "./bin/entrypoint" ]
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ file and load that either using the `--config` CLI parameter or using environmen
     - `LOG_LEVEL` (string)
     - `LOG_FILTER` (string)
     - `LOG_PATH` (string)
+    - `LOG_NO_COLORS` (boolean) - if set the output won't be colorized
 
 ### Database
 

--- a/src/@types/colors/index.d.ts
+++ b/src/@types/colors/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'colors/lib/system/supports-colors' {
+  export function supportsColor(): boolean
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,8 @@
 import { createLogger, format, transports, addColors, Logger as RealLogger } from 'winston'
 import * as Transport from 'winston-transport'
 
-import colors from 'colors'
+import colors from 'colors/safe'
+import { supportsColor } from 'colors/lib/system/supports-colors'
 import config from 'config'
 
 import { Logger } from './definitions'
@@ -132,7 +133,7 @@ function initLogging (): void {
       upperCaseLevel(),
       // format.padLevels(),
       format.timestamp({ format: 'DD/MM hh:mm:ss' }),
-      format.colorize(),
+      !supportsColor() || process.env.LOG_NO_COLORS === 'true' ? format(i => i)() : format.colorize(),
       format.printf(info => {
         let message: string
         const { service, ...rest } = info.metadata

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,6 +8,8 @@ import config from 'config'
 import { Logger } from './definitions'
 import { inspect } from 'util'
 
+const COLORS_ENABLED = supportsColor() && !process.env.LOG_NO_COLORS
+
 // Inspired from https://github.com/visionmedia/debug
 const names: RegExp[] = []
 const skips: RegExp[] = []
@@ -133,7 +135,7 @@ function initLogging (): void {
       upperCaseLevel(),
       // format.padLevels(),
       format.timestamp({ format: 'DD/MM hh:mm:ss' }),
-      !supportsColor() || process.env.LOG_NO_COLORS === 'true' ? format(i => i)() : format.colorize(),
+      format.colorize(),
       format.printf(info => {
         let message: string
         const { service, ...rest } = info.metadata
@@ -149,8 +151,9 @@ function initLogging (): void {
         }
 
         return message
-      })
-    ),
+      }),
+      COLORS_ENABLED ? format(i => i)() : format.uncolorize()
+  ),
     transports: transportsSet
   })
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -153,7 +153,7 @@ function initLogging (): void {
         return message
       }),
       COLORS_ENABLED ? format(i => i)() : format.uncolorize()
-  ),
+    ),
     transports: transportsSet
   })
 }


### PR DESCRIPTION
Resolves #417 

Uses the `supportsColor()` and also allows env. variable override.