### PR TITLE
fix(storage): groups by provider to get min max available capacity

### DIFF
--- a/src/services/storage/utils.ts
+++ b/src/services/storage/utils.ts
@@ -55,7 +55,7 @@ export function getMinMaxAvailableCapacityQuery (minMax: MinMax): string {
       "storage_offer"
     LEFT OUTER JOIN
       "storage_agreement" as "storage_agreement" ON "storage_offer"."provider" = "storage_agreement"."offerId"
-    GROUP BY offerId
+    GROUP BY provider
     ORDER BY availableCapacity ${minMax === 1 ? 'DESC' : 'ASC'}
     LIMIT 1
      `

--- a/test/unit/services/storage/services.spec.ts
+++ b/test/unit/services/storage/services.spec.ts
@@ -19,20 +19,24 @@ describe('Services', () => {
     })
     it('should retrieve min/max value for availableCapacity', async () => {
       await Offer.bulkCreate([
-        { provider: 'provider1', totalCapacity: 100, peerId: '1' },
-        { provider: 'provider2', totalCapacity: 100, peerId: '2' }
+        { provider: 'provider1', totalCapacity: '102400', peerId: '1' },
+        { provider: 'provider2', totalCapacity: '100', peerId: '2' },
+        { provider: 'provider3', totalCapacity: '1126', peerId: '3' },
+        { provider: 'provider4', totalCapacity: '1', peerId: '4' }
       ])
       await Agreement.bulkCreate([
-        { agreementReference: '123', size: 10, offerId: 'provider1' },
-        { agreementReference: '1234', size: 10, offerId: 'provider1' }
+        { agreementReference: '11', size: '1024', offerId: 'provider1' },
+        { agreementReference: '12', size: '1024', offerId: 'provider1' },
+        { agreementReference: '31', size: '1024', offerId: 'provider3' }
       ])
 
       const availableCapacityService = new AvailableCapacityService({ Model: Offer })
       const expectedRes = {
-        min: 80,
-        max: 100
+        min: 1,
+        max: 100352
       }
       const minMax = await availableCapacityService.get()
+
       expect(minMax).to.be.deep.equal(expectedRes)
     })
   })


### PR DESCRIPTION
When calculating the availableCapacity I was wrongly grouping by `offerId`. We should group by `provider` that's the primary key for offers table