### PR TITLE
chore: release version v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="1.3.1"></a>
+## [1.3.1](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.3.0...v1.3.1) (2021-02-01)
+
+### Bug Fixes
+ - update `web3-events` lib (reorg handling issue)
+
+
 <a name="1.3.0"></a>
 # [1.3.0](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.2.1...v1.3.0) (2021-01-21)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-marketplace-cache",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Caching server for RIF Marketplace",
   "keywords": [
     "RIF",


### PR DESCRIPTION
## [1.3.1](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.3.0...v1.3.1) (2021-02-01)

### Bug Fixes
 - update `web3-events` lib (reorg handling issue)
