### PR TITLE
chore: disable order of events

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -154,8 +154,8 @@
       // Will process one event at a time
       serialProcessing: true,
 
-      // Will order events in the groupped batches from all the Emitters
-      orderedProcessing: true,
+      // Will not order events in grouped batches from all the Emitters
+      orderedProcessing: false,
 
       name: 'rns'
     },


### PR DESCRIPTION
* Disable ordering of events for RNS for now as this is causing issues with confirmations and it is not really mandatory.