### PR TITLE
Release 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+<a name="1.3.3"></a>
+## [1.3.3](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.3.0...v1.3.3) (2021-03-04)
+
+
+### Bug Fixes
+
+* **rns:** adds post find pagination hook ([#529](https://github.com/rsksmart/rif-marketplace-cache/issues/529)) ([4f72426](https://github.com/rsksmart/rif-marketplace-cache/commit/4f72426b9acf538b57077999caf1eb0db23594fa))
+* **rns:** removes pagination ([759ad55](https://github.com/rsksmart/rif-marketplace-cache/commit/759ad55f6200a093457b4bfce909813413d135fd))
+* do not expose error stack trace to client ([#556](https://github.com/rsksmart/rif-marketplace-cache/issues/556)) ([6ae31d4](https://github.com/rsksmart/rif-marketplace-cache/commit/6ae31d4b43262d181ca1f946ae1218e5dfea36f8))
+
+
+### Features
+
+* **rns:** adds filter by fiat to offers ([58cca7c](https://github.com/rsksmart/rif-marketplace-cache/commit/58cca7cdbec1cf13843dab00273c72843a410449))
+* **rns:** copies and adapts usdPrice calc ([2bef1cb](https://github.com/rsksmart/rif-marketplace-cache/commit/2bef1cb98f0b442daf6fed3396fec4810a74c5c8))
+
+
+
 <a name="1.3.2"></a>
 ## [1.3.2](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.3.0...v1.3.2) (2021-02-02)
 

--- a/config/rsktestnet.json5
+++ b/config/rsktestnet.json5
@@ -26,14 +26,14 @@
     storageManager: {
       contractAddress: "0x839856c0eC1aA2AeD25D47Fd3DDB7A14Dac3e76d",
       eventsEmitter: {
-        startingBlock: 1425147,
+        startingBlock: 1656800,
         confirmations: 8
       }
     },
     staking: {
       contractAddress: "0x11bE792f8fcfC84897b88e149dD3fb66b422256f",
       eventsEmitter: {
-        startingBlock: 1425147,
+        startingBlock: 1656787,
         confirmations: 8
       }
     },

--- a/config/staging.json5
+++ b/config/staging.json5
@@ -26,14 +26,14 @@
     storageManager: {
       contractAddress: "0xaF37117a4907331DC49b05bDC1DE920F12dBF715",
       eventsEmitter: {
-        startingBlock: 1333889,
+        startingBlock: 1656755,
         confirmations: 3
       }
     },
     staking: {
       contractAddress: "0xF1573D262924abE24334FDDD62c6Ba58288d2f8c",
       eventsEmitter: {
-        startingBlock: 1333904,
+        startingBlock: 1656733,
         confirmations: 3
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-marketplace-cache",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Caching server for RIF Marketplace",
   "keywords": [
     "RIF",


### PR DESCRIPTION
<a name="1.3.3"></a>
## [1.3.3](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.3.0...v1.3.3) (2021-03-04)


### Bug Fixes

* **rns:** adds post find pagination hook ([#529](https://github.com/rsksmart/rif-marketplace-cache/issues/529)) ([4f72426](https://github.com/rsksmart/rif-marketplace-cache/commit/4f72426b9acf538b57077999caf1eb0db23594fa))
* **rns:** removes pagination ([759ad55](https://github.com/rsksmart/rif-marketplace-cache/commit/759ad55f6200a093457b4bfce909813413d135fd))
* do not expose error stack trace to client ([#556](https://github.com/rsksmart/rif-marketplace-cache/issues/556)) ([6ae31d4](https://github.com/rsksmart/rif-marketplace-cache/commit/6ae31d4b43262d181ca1f946ae1218e5dfea36f8))


### Features

* **rns:** adds filter by fiat to offers ([58cca7c](https://github.com/rsksmart/rif-marketplace-cache/commit/58cca7cdbec1cf13843dab00273c72843a410449))
* **rns:** copies and adapts usdPrice calc ([2bef1cb](https://github.com/rsksmart/rif-marketplace-cache/commit/2bef1cb98f0b442daf6fed3396fec4810a74c5c8))

