### PR TITLE
Release 1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.3.4](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.3.3...v1.3.4) (2021-03-05)
+
+### Bug Fixes
+* **build:** fix typescript compilation ([#560](https://github.com/rsksmart/rif-marketplace-cache/pull/560))
+
+
 <a name="1.3.3"></a>
 ## [1.3.3](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.3.0...v1.3.3) (2021-03-04)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-marketplace-cache",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-marketplace-cache",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Caching server for RIF Marketplace",
   "keywords": [
     "RIF",


### PR DESCRIPTION
## [1.3.4](https://github.com/rsksmart/rif-marketplace-cache/compare/v1.3.3...v1.3.4) (2021-03-05)

### Bug Fixes
* **build:** fix typescript compilation ([#560](https://github.com/rsksmart/rif-marketplace-cache/pull/560))
