### PR TITLE
fix(notifier): stop defaulting port param

### DIFF
--- a/src/services/notifier/notifierService/provider.ts
+++ b/src/services/notifier/notifierService/provider.ts
@@ -39,7 +39,7 @@ interface NotifierServiceProvider {
 }
 
 export class NotifierSvcProvider extends ServiceProvider<NotifierResult<any>> implements NotifierServiceProvider {
-  constructor ({ host, port = '8080' }: Partial<ClientRequestArgs>) {
+  constructor ({ host, port }: Partial<ClientRequestArgs>) {
     super()
 
     this.defaultOptions = { host, port }


### PR DESCRIPTION
The port parameter to the NotifierSvcProvider constructor isn't necessary and causes issues where port isn't defined in the url as the default http port is 80 not 8080. This would also be problem for "portless" https urls.