### PR TITLE
feat(notifier): includes url in plan object of subscriptions

### DIFF
--- a/src/services/notifier/hooks/subscriptions.hook.ts
+++ b/src/services/notifier/hooks/subscriptions.hook.ts
@@ -28,13 +28,22 @@ export default {
                 {
                   model: NotifierChannelModel,
                   as: 'channels',
-                  attributes: ['name'],
                   required: true
                 }
-              ]
+              ],
+              attributes: {
+                include: [
+                  [
+                    literal('(SELECT url FROM notifier_provider AS provider WHERE SubscriptionModel.providerId = provider.provider)'),
+                    'url'
+                  ]
+                ]
+              }
             }
           ],
-          attributes: { exclude: ['subscriptionPlanId'] }
+          attributes: {
+            exclude: ['subscriptionPlanId']
+          }
         }
       }
     ],


### PR DESCRIPTION
Includes `url` property under `plan` object when fetching subscriptions