### PR TITLE
feat(notifier): updates subscriptions from provider service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ oclif.manifest.json
 # Default data dir
 /data
 /data-test
+
+# misc
+.DS_Store

--- a/src/services/notifier/hooks/subscriptions.hook.ts
+++ b/src/services/notifier/hooks/subscriptions.hook.ts
@@ -44,7 +44,35 @@ export default {
         }
       }
     ],
-    get: [],
+    get: [
+      (context: HookContext) => {
+        context.params.sequelize = {
+          raw: false,
+          nest: true,
+          include: [
+            {
+              model: PlanModel,
+              as: 'plan',
+              where: literal('plan.id = subscriptionPlanId'),
+              include: [
+                {
+                  model: NotifierChannelModel,
+                  as: 'channels',
+                  attributes: ['name'],
+                  required: true
+                }
+              ]
+            },
+            {
+              model: ProviderModel,
+              as: 'provider',
+              attributes: ['url']
+            }
+          ],
+          attributes: { exclude: ['subscriptionPlanId'] }
+        }
+      }
+    ],
     create: disallow('external'),
     update: disallow('external'),
     patch: disallow('external'),

--- a/src/services/notifier/hooks/subscriptions.hook.ts
+++ b/src/services/notifier/hooks/subscriptions.hook.ts
@@ -3,6 +3,7 @@ import { disallow } from 'feathers-hooks-common'
 import { literal } from 'sequelize'
 import NotifierChannelModel from '../models/notifier-channel.model'
 import PlanModel from '../models/plan.model'
+import ProviderModel from '../models/provider.model'
 
 export default {
   before: {
@@ -32,6 +33,11 @@ export default {
                   required: true
                 }
               ]
+            },
+            {
+              model: ProviderModel,
+              as: 'provider',
+              attributes: ['url']
             }
           ],
           attributes: { exclude: ['subscriptionPlanId'] }

--- a/src/services/notifier/hooks/subscriptions.hook.ts
+++ b/src/services/notifier/hooks/subscriptions.hook.ts
@@ -1,6 +1,7 @@
 import { HookContext } from '@feathersjs/feathers'
 import { disallow } from 'feathers-hooks-common'
-import { literal } from 'sequelize'
+import { Op, literal } from 'sequelize'
+
 import NotifierChannelModel from '../models/notifier-channel.model'
 import PlanModel from '../models/plan.model'
 import ProviderModel from '../models/provider.model'
@@ -15,35 +16,7 @@ export default {
         return context
       }
     ],
-    find: [
-      (context: HookContext) => {
-        context.params.sequelize = {
-          raw: false,
-          nest: true,
-          include: [
-            {
-              model: PlanModel,
-              as: 'plan',
-              where: literal('plan.id = subscriptionPlanId'),
-              include: [
-                {
-                  model: NotifierChannelModel,
-                  as: 'channels',
-                  attributes: ['name'],
-                  required: true
-                }
-              ]
-            },
-            {
-              model: ProviderModel,
-              as: 'provider',
-              attributes: ['url']
-            }
-          ],
-          attributes: { exclude: ['subscriptionPlanId'] }
-        }
-      }
-    ],
+    find: [],
     get: [
       (context: HookContext) => {
         context.params.sequelize = {

--- a/src/services/notifier/hooks/subscriptions.hook.ts
+++ b/src/services/notifier/hooks/subscriptions.hook.ts
@@ -1,10 +1,5 @@
 import { HookContext } from '@feathersjs/feathers'
 import { disallow } from 'feathers-hooks-common'
-import { Op, literal } from 'sequelize'
-
-import NotifierChannelModel from '../models/notifier-channel.model'
-import PlanModel from '../models/plan.model'
-import ProviderModel from '../models/provider.model'
 
 export default {
   before: {
@@ -17,35 +12,7 @@ export default {
       }
     ],
     find: [],
-    get: [
-      (context: HookContext) => {
-        context.params.sequelize = {
-          raw: false,
-          nest: true,
-          include: [
-            {
-              model: PlanModel,
-              as: 'plan',
-              where: literal('plan.id = subscriptionPlanId'),
-              include: [
-                {
-                  model: NotifierChannelModel,
-                  as: 'channels',
-                  attributes: ['name'],
-                  required: true
-                }
-              ]
-            },
-            {
-              model: ProviderModel,
-              as: 'provider',
-              attributes: ['url']
-            }
-          ],
-          attributes: { exclude: ['subscriptionPlanId'] }
-        }
-      }
-    ],
+    get: [],
     create: disallow('external'),
     update: disallow('external'),
     patch: disallow('external'),

--- a/src/services/notifier/hooks/subscriptions.hook.ts
+++ b/src/services/notifier/hooks/subscriptions.hook.ts
@@ -1,17 +1,124 @@
 import { HookContext } from '@feathersjs/feathers'
 import { disallow } from 'feathers-hooks-common'
+import { literal, Op } from 'sequelize'
+import NotifierChannelModel from '../models/notifier-channel.model'
+import PlanModel from '../models/plan.model'
+import ProviderModel from '../models/provider.model'
+import SubscriptionModel from '../models/subscription.model'
+import { updateSubscriptionsBy } from '../utils/updaterUtils'
+
+type HashesByProviderAndConsumer = Record<string, Record<string, string[]>>
 
 export default {
   before: {
     all: [
-      (context: HookContext) => {
+      (context: HookContext): HookContext => {
         context.params.sequelize = {
           raw: false
         }
         return context
       }
     ],
-    find: [],
+    find: [
+      async (context: HookContext): Promise<HookContext> => {
+        // we don't relay on status, notificationBalance and paid properties, they don't mirror their values on the notifier provider
+        // so we ignore them in the original query, update them and then run the original query
+        const { query } = context.params
+        const tmpQuery = { ...query }
+
+        if (tmpQuery) {
+          delete tmpQuery.status
+          delete tmpQuery.notificationBalance
+          delete tmpQuery.paid
+        }
+
+        // run query ignoring non-relayable fields
+        const accountSubscriptions = await SubscriptionModel.findAll({
+          raw: false,
+          nest: true,
+          where: tmpQuery,
+          include: [
+            {
+              model: ProviderModel,
+              as: 'provider',
+              attributes: ['url']
+            }
+          ]
+        })
+
+        // provider -> {consumer} -> [hashes]
+        const hashesByProviderAndConsumer = accountSubscriptions.reduce(
+          (acc: HashesByProviderAndConsumer, current: SubscriptionModel) => {
+            const { consumer, hash, provider: { url } } = current
+
+            if (!acc[url]) {
+              acc[url] = {}
+              acc[url][consumer] = [hash]
+            } else {
+              acc[url][consumer] = [...acc[url][consumer], hash]
+            }
+            return acc
+          }, {}
+        )
+
+        // updates DB fetching the involved subscriptions directly from the notifier service
+        const updateDataPromises: Promise<void>[] = []
+        Object.keys(hashesByProviderAndConsumer).forEach(providerUrl => {
+          const providerSubscriptions = hashesByProviderAndConsumer[providerUrl]
+          Object.keys(providerSubscriptions).forEach(consumerAddress => {
+            const hashes = providerSubscriptions[consumerAddress]
+            updateDataPromises.push(updateSubscriptionsBy(providerUrl, consumerAddress, hashes))
+          })
+        })
+
+        await Promise.all(updateDataPromises)
+        return context
+      },
+      (context: HookContext): HookContext => {
+        const { query, sequelize } = context.params
+
+        if (query?.status) {
+          const { $ne } = query.status
+
+          if ($ne) {
+            sequelize.where = {
+              ...sequelize.where,
+              status: {
+                [Op.notLike]: `%${$ne}%`
+              }
+            }
+          }
+        }
+
+        context.params.sequelize = {
+          raw: false,
+          nest: true,
+          where: query,
+          include: [
+            {
+              model: PlanModel,
+              as: 'plan',
+              where: literal('plan.id = subscriptionPlanId'),
+              include: [
+                {
+                  model: NotifierChannelModel,
+                  as: 'channels',
+                  attributes: ['name'],
+                  required: true
+                }
+              ]
+            },
+            {
+              model: ProviderModel,
+              as: 'provider',
+              attributes: ['url']
+            }
+          ],
+          attributes: { exclude: ['subscriptionPlanId'] }
+        }
+        return context
+      }
+    ],
     get: [],
     create: disallow('external'),
     update: disallow('external'),

--- a/src/services/notifier/services.ts
+++ b/src/services/notifier/services.ts
@@ -24,8 +24,6 @@ export class SubscriptionsService extends Service {
   emit?: EmitFn
 
   async find ({ query }: Params): Promise<SubscriptionModel[]> {
-    await new Promise(resolve => setTimeout(resolve, 3000))
-
     // we don't relay on status, notificationBalance and paid properties, they don't mirror their values on the notifier provider
     // so we ignore them in the original query, update them and then run the original query
     const tmpQuery = { ...query }

--- a/src/services/notifier/services.ts
+++ b/src/services/notifier/services.ts
@@ -4,6 +4,12 @@ import BigNumber from 'bignumber.js'
 
 import type { EmitFn } from '../../definitions'
 import NotifierStakeModel, { getStakesForAccount } from './models/notifier-stake.model'
+import SubscriptionModel from './models/subscription.model'
+import ProviderModel from './models/provider.model'
+import { loggingFactory } from '../../logger'
+import { updateSubscriptionsBy } from './utils/updaterUtils'
+
+const logger = loggingFactory('notifier:service')
 
 export class ProviderService extends Service {
   emit?: EmitFn
@@ -14,12 +20,62 @@ export class PlansService extends Service {
 
 export class SubscriptionsService extends Service {
   emit?: EmitFn
+
+  async get(consumer: string): Promise<SubscriptionModel[]> {
+    // find all subscriptions by consumer
+    const accountSubscriptions = await SubscriptionModel.findAll({
+      where: {
+        consumer: consumer.toLowerCase()
+      },
+      include: [
+        {
+          model: ProviderModel,
+          as: 'provider',
+          attributes: ['url']
+        }
+      ]
+    })
+
+    // group them by provider url - assumes url of provider is unique
+    const subsByProvider = accountSubscriptions.reduce(
+      (acc: Record<string, SubscriptionModel[]>, current: SubscriptionModel) => {
+        const { provider: { url } } = current
+
+        if (!acc[url]) {
+          acc[url] = [current]
+        } else {
+          acc[url] = [...acc[url], current]
+        }
+        return acc
+      }, {}
+    )
+
+    // update all subscriptions with latest provider status
+    const promises: Promise<any>[] = []
+    Object.keys(subsByProvider).forEach(providerUrl => promises.push(
+      updateSubscriptionsBy(providerUrl, consumer, subsByProvider[providerUrl])
+    ))
+    await Promise.all(promises)
+    // query DB with updated data
+    return SubscriptionModel.findAll({
+      where: {
+        consumer: consumer.toLowerCase()
+      },
+      include: [
+        {
+          model: ProviderModel,
+          as: 'provider',
+          attributes: ['url']
+        }
+      ]
+    })
+  }
 }
 
 export class NotifierStakeService extends Service {
   emit?: EmitFn
 
-  async get (account: string): Promise<{ totalStakedFiat: string, stakes: Array<NotifierStakeModel> }> {
+  async get(account: string): Promise<{ totalStakedFiat: string, stakes: Array<NotifierStakeModel> }> {
     const sequelize = this.Model.sequelize
 
     const query = getStakesForAccount(sequelize, account.toLowerCase())

--- a/src/services/notifier/services.ts
+++ b/src/services/notifier/services.ts
@@ -1,15 +1,9 @@
 import { Service } from 'feathers-sequelize'
-import { QueryTypes, Op, literal } from 'sequelize'
+import { QueryTypes } from 'sequelize'
 import BigNumber from 'bignumber.js'
 
 import type { EmitFn } from '../../definitions'
 import NotifierStakeModel, { getStakesForAccount } from './models/notifier-stake.model'
-import SubscriptionModel from './models/subscription.model'
-import ProviderModel from './models/provider.model'
-import { updateSubscriptionsBy } from './utils/updaterUtils'
-import PlanModel from './models/plan.model'
-import NotifierChannelModel from './models/notifier-channel.model'
-import { Params } from '@feathersjs/feathers'
 
 export class ProviderService extends Service {
   emit?: EmitFn
@@ -18,97 +12,8 @@ export class PlansService extends Service {
   emit?: EmitFn
 }
 
-type HashesByProviderAndConsumer = Record<string, Record<string, string[]>>
-
 export class SubscriptionsService extends Service {
   emit?: EmitFn
-
-  async find ({ query }: Params): Promise<SubscriptionModel[]> {
-    // we don't relay on status, notificationBalance and paid properties, they don't mirror their values on the notifier provider
-    // so we ignore them in the original query, update them and then run the original query
-    const tmpQuery = { ...query }
-
-    if (tmpQuery) {
-      delete tmpQuery.status
-      delete tmpQuery.notificationBalance
-      delete tmpQuery.paid
-    }
-
-    // run query ignoring non-relayable fields
-    const accountSubscriptions = await SubscriptionModel.findAll({
-      raw: false,
-      nest: true,
-      where: tmpQuery,
-      include: [
-        {
-          model: ProviderModel,
-          as: 'provider',
-          attributes: ['url']
-        }
-      ]
-    })
-
-    // provider -> {consumer} -> [hashes]
-    const hashesByProviderAndConsumer = accountSubscriptions.reduce(
-      (acc: HashesByProviderAndConsumer, current: SubscriptionModel) => {
-        const { consumer, hash, provider: { url } } = current
-
-        if (!acc[url]) {
-          acc[url] = {}
-          acc[url][consumer] = [hash]
-        } else {
-          acc[url][consumer] = [...acc[url][consumer], hash]
-        }
-        return acc
-      }, {}
-    )
-
-    // updates DB fetching the involved subscriptions directly from the notifier service
-    const updateDataPromises: Promise<void>[] = []
-    Object.keys(hashesByProviderAndConsumer).forEach(providerUrl => {
-      const providerSubscriptions = hashesByProviderAndConsumer[providerUrl]
-      Object.keys(providerSubscriptions).forEach(consumerAddress => {
-        const hashes = providerSubscriptions[consumerAddress]
-        updateDataPromises.push(updateSubscriptionsBy(providerUrl, consumerAddress, hashes))
-      })
-    })
-
-    await Promise.all(updateDataPromises)
-
-    if (query?.status) {
-      const { $ne } = query.status
-      query.status = {
-        [Op.notLike]: `%${$ne}%`
-      }
-    }
-
-    return SubscriptionModel.findAll({
-      raw: false,
-      nest: true,
-      where: query,
-      include: [
-        {
-          model: PlanModel,
-          as: 'plan',
-          where: literal('plan.id = subscriptionPlanId'),
-          include: [
-            {
-              model: NotifierChannelModel,
-              as: 'channels',
-              attributes: ['name'],
-              required: true
-            }
-          ]
-        },
-        {
-          model: ProviderModel,
-          as: 'provider',
-          attributes: ['url']
-        }
-      ],
-      attributes: { exclude: ['subscriptionPlanId'] }
-    })
-  }
 }
 
 export class NotifierStakeService extends Service {

--- a/src/services/notifier/services.ts
+++ b/src/services/notifier/services.ts
@@ -1,5 +1,5 @@
 import { Service } from 'feathers-sequelize'
-import { QueryTypes } from 'sequelize'
+import { QueryTypes, Op } from 'sequelize'
 import BigNumber from 'bignumber.js'
 
 import type { EmitFn } from '../../definitions'
@@ -18,8 +18,83 @@ export class PlansService extends Service {
   emit?: EmitFn
 }
 
+type HashesByProviderAndConsumer = Record<string, Record<string, string[]>>
+
 export class SubscriptionsService extends Service {
   emit?: EmitFn
+
+  async find(params: any): Promise<SubscriptionModel[]> {
+    console.log('entro!');
+
+    const { query } = params
+    // we don't relay on status, notificationBalance and paid properties as they might be out of date
+    // so we ignore them in the original query, update them and then run the original query
+    const tmpQuery = { ...query }
+    delete query.status
+    delete query.notificationBalance
+    delete query.paid
+
+    console.log({ tmpQuery })
+
+    // run query ignoring outdated fields
+    const accountSubscriptions = await SubscriptionModel.findAll({
+      where: tmpQuery,
+      include: [
+        {
+          model: ProviderModel,
+          as: 'provider',
+          attributes: ['url']
+        }
+      ]
+    })
+
+    console.log('hashes by provider and consumer')
+
+    // provider -> {consumer} -> [hashes]
+    const hashesByProviderAndConsumer = accountSubscriptions.reduce(
+      (acc: HashesByProviderAndConsumer, current: SubscriptionModel) => {
+        const { consumer, hash, provider: { url } } = current
+
+        if (!acc[url]) {
+          acc[url] = {}
+          acc[url][consumer] = [hash]
+        } else {
+          acc[url][consumer] = [...acc[url][consumer], hash]
+        }
+        return acc
+      }, {}
+    )
+
+    console.log({ hashesByProviderAndConsumer })
+    console.log('before fetching from svc')
+
+    // updates DB fetching the involved subscriptions directly from notifier service
+    const updateDataPromises: Promise<any>[] = []
+    Object.keys(hashesByProviderAndConsumer).forEach(providerUrl => {
+      const providerSubscriptions = hashesByProviderAndConsumer[providerUrl]
+      Object.keys(providerSubscriptions).forEach(consumerAddress => {
+        const hashes = providerSubscriptions[consumerAddress]
+        updateDataPromises.push(updateSubscriptionsBy(providerUrl, consumerAddress, hashes))
+      })
+    })
+
+    await Promise.all(updateDataPromises)
+    console.log('all svc done')
+    console.log({ query })
+
+    return SubscriptionModel.findAll({
+      where: query,
+      include: [
+        {
+          model: ProviderModel,
+          as: 'provider',
+          attributes: ['url']
+        }
+      ]
+    })
+
+    // return updatedResult
+  }
 
   async get(consumer: string): Promise<SubscriptionModel[]> {
     // find all subscriptions by consumer
@@ -36,7 +111,7 @@ export class SubscriptionsService extends Service {
       ]
     })
 
-    // group them by provider url - assumes url of provider is unique
+    // group them by provider url
     const subsByProvider = accountSubscriptions.reduce(
       (acc: Record<string, SubscriptionModel[]>, current: SubscriptionModel) => {
         const { provider: { url } } = current
@@ -53,13 +128,14 @@ export class SubscriptionsService extends Service {
     // update all subscriptions with latest provider status
     const promises: Promise<any>[] = []
     Object.keys(subsByProvider).forEach(providerUrl => promises.push(
-      updateSubscriptionsBy(providerUrl, consumer, subsByProvider[providerUrl])
+      updateSubscriptionsBy(providerUrl, consumer, subsByProvider[providerUrl].map(subs => subs.hash))
     ))
     await Promise.all(promises)
     // query DB with updated data
     return SubscriptionModel.findAll({
       where: {
-        consumer: consumer.toLowerCase()
+        consumer: consumer.toLowerCase(),
+        status: { [Op.notLike]: 'PENDING' }
       },
       include: [
         {

--- a/src/services/notifier/utils/updaterUtils.ts
+++ b/src/services/notifier/utils/updaterUtils.ts
@@ -1,11 +1,10 @@
-import { where } from 'sequelize'
 import NotifierChannelModel from '../models/notifier-channel.model'
 import PlanModel from '../models/plan.model'
 import PriceModel from '../models/price.model'
 import SubscriptionModel from '../models/subscription.model'
 import { NotifierSvcProvider, SubscriptionPlanDTO } from '../notifierService/provider'
 
-function deactivateDeletedPlans(currentPlans: Array<PlanModel>, incomingPlans: Array<SubscriptionPlanDTO>): void {
+function deactivateDeletedPlans (currentPlans: Array<PlanModel>, incomingPlans: Array<SubscriptionPlanDTO>): void {
   if (currentPlans && incomingPlans) {
     const deletedPlans: Array<PlanModel> = currentPlans.filter(({
       planId: currentId,
@@ -37,7 +36,7 @@ function deactivateDeletedPlans(currentPlans: Array<PlanModel>, incomingPlans: A
   }
 }
 
-export async function deactivateDeletedPlansForProvider(provider: string, url: string): Promise<void> {
+export async function deactivateDeletedPlansForProvider (provider: string, url: string): Promise<void> {
   const currentPlans = await PlanModel.findAll({
     where: { providerId: provider },
     include: [{ model: NotifierChannelModel }, { model: PriceModel }]
@@ -50,7 +49,7 @@ export async function deactivateDeletedPlansForProvider(provider: string, url: s
 
 export const updateSubscriptionsBy = async (
   providerUrl: string, consumerAddress: string, subsHashesToUpdate: string[]
-): Promise<any> => {
+): Promise<void> => {
   const [host, port] = providerUrl.split(/(?::)(\d*)$/, 2)
   const svcProvider = new NotifierSvcProvider({ host, port })
   const subscriptionsDTO: any[] = await svcProvider.getSubscriptions(consumerAddress, subsHashesToUpdate)
@@ -71,6 +70,4 @@ export const updateSubscriptionsBy = async (
       )
     )
   })
-
-  return promises
 }

--- a/src/services/notifier/utils/updaterUtils.ts
+++ b/src/services/notifier/utils/updaterUtils.ts
@@ -49,12 +49,11 @@ export async function deactivateDeletedPlansForProvider(provider: string, url: s
 }
 
 export const updateSubscriptionsBy = async (
-  providerUrl: string, consumerAddress: string, subscriptions: SubscriptionModel[]
+  providerUrl: string, consumerAddress: string, subsHashesToUpdate: string[]
 ): Promise<any> => {
   const [host, port] = providerUrl.split(/(?::)(\d*)$/, 2)
   const svcProvider = new NotifierSvcProvider({ host, port })
-  const hashes = subscriptions.map(subscription => subscription.hash)
-  const subscriptionsDTO: any[] = await svcProvider.getSubscriptions(consumerAddress, hashes)
+  const subscriptionsDTO: any[] = await svcProvider.getSubscriptions(consumerAddress, subsHashesToUpdate)
 
   const promises: Promise<[number, SubscriptionModel[]]>[] = []
   subscriptionsDTO.forEach(subscriptionDTO => {

--- a/src/services/notifier/utils/updaterUtils.ts
+++ b/src/services/notifier/utils/updaterUtils.ts
@@ -70,4 +70,5 @@ export const updateSubscriptionsBy = async (
       )
     )
   })
+  await Promise.all(promises)
 }

--- a/src/services/notifier/utils/updaterUtils.ts
+++ b/src/services/notifier/utils/updaterUtils.ts
@@ -54,21 +54,15 @@ export const updateSubscriptionsBy = async (
   const svcProvider = new NotifierSvcProvider({ host, port })
   const subscriptionsDTO: any[] = await svcProvider.getSubscriptions(consumerAddress, subsHashesToUpdate)
 
-  const promises: Promise<[number, SubscriptionModel[]]>[] = []
-  subscriptionsDTO.forEach(subscriptionDTO => {
-    const {
-      hash,
-      status,
-      paid,
-      notificationBalance
-    } = subscriptionDTO
-
-    promises.push(
-      SubscriptionModel.update(
-        { status, paid, notificationBalance },
-        { where: { hash } }
-      )
+  await Promise.all(subscriptionsDTO.map(({
+    hash,
+    status,
+    paid,
+    notificationBalance
+  }) =>
+    SubscriptionModel.update(
+      { status, paid, notificationBalance },
+      { where: { hash } }
     )
-  })
-  await Promise.all(promises)
+  ))
 }


### PR DESCRIPTION
This PR solves the problem of notifier subscriptions data not being up to date when fetching them.
The process is the following:
- When a fetch subscriptions request is received, we ignore the fields we don't relay on `(status, notificationBalance, paid)`.
- Runs the query in our DB to get the related hashes
- Updates the involved subscriptions from notifier services
- Runs the original query once the data has been updated

Solves [RMKT-784](https://rsklabs.atlassian.net/jira/software/projects/RMKT/boards/60?selectedIssue=RMKT-784)

_This PR should be squashed_