### PR TITLE
fix(notifier): use correct format for previousSubscription

### DIFF
--- a/src/services/notifier/handlers/provider.ts
+++ b/src/services/notifier/handlers/provider.ts
@@ -69,12 +69,13 @@ export const handlers = {
       status,
       notificationBalance,
       subscriptionPlanId,
-      previousSubscription,
+      previousSubscription: previousSubscriptionModel,
       topics,
       signature
     } = subscriptionDTO
 
     const tokenSymbol = getTokenSymbol(tokenAddress, SupportedServices.NOTIFIER).toLowerCase()
+    const previousSubscriptionHash = previousSubscriptionModel?.hash
 
     const subscription = {
       providerId: provider,
@@ -88,7 +89,7 @@ export const handlers = {
       status,
       notificationBalance,
       subscriptionPlanId,
-      previousSubscription,
+      previousSubscription: previousSubscriptionHash,
       topics,
       signature
     }


### PR DESCRIPTION
Uses proper format for previous subscription.
Done and discovered by @vjgene while renewing subscriptions