### PR TITLE
fix(notifier): adds params to query unique plan

### DIFF
--- a/src/services/notifier/hooks/subscriptions.hook.ts
+++ b/src/services/notifier/hooks/subscriptions.hook.ts
@@ -100,7 +100,7 @@ export default {
             {
               model: PlanModel,
               as: 'plan',
-              where: literal('plan.id = subscriptionPlanId'),
+              where: literal('plan.id = subscriptionPlanId AND plan.planStatus = "ACTIVE" AND plan.providerId = SubscriptionModel.providerId'),
               include: [
                 {
                   model: NotifierChannelModel,


### PR DESCRIPTION
Relates to https://rsklabs.atlassian.net/browse/RMKT-792.

What needed to be done is to follow the design change of the plan table (done as feature for url switching) when querying from subscription hook.