### PR TITLE
fix(notifier): catches unable to establish provider connection error

### DIFF
--- a/src/services/notifier/handlers/provider.ts
+++ b/src/services/notifier/handlers/provider.ts
@@ -51,7 +51,13 @@ export const handlers = {
 
     const [host, port] = providerIns.url.split(/(?::)(\d*)$/, 2)
     const notifierService = new NotifierSvcProvider({ host, port })
-    const [subscriptionDTO] = await notifierService.getSubscriptions(consumer, [hash])
+
+    let subscriptionDTO
+    try {
+      [subscriptionDTO] = await notifierService.getSubscriptions(consumer, [hash])
+    } catch (error) {
+      logger.error(`Couldn't get subscriptions from notifier provider ${providerIns.url}`)
+    }
 
     if (!subscriptionDTO) return
 


### PR DESCRIPTION
Throwing an error when unable to establish connection with a notifier provider is breaking the `precache` execution. This PR catches, logs that error and keeps with the execution