### PR TITLE
feat(notifier): adds ability to withdraw funds as a provider

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -167,7 +167,8 @@
         topics: [
           [ // It needs to be a "double array" because that represents an "or" of the topics and not "and"
             'ProviderRegistered(address,string)',
-            'SubscriptionCreated(bytes32,address,address,uint256,address)'
+            'SubscriptionCreated(bytes32,address,address,uint256,address)',
+            'FundsWithdrawn(address,bytes32,uint256,address)'
           ]
         ],
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -303,7 +303,9 @@ export type StorageEvents = StorageOfferEvents | StorageAgreementEvents | StakeE
 
 /// //////////////////////////////////////////////////////////////////////////////////////////////////
 // NOTIFIER
-export type NotificationManagerEvents = notifierEvents.ProviderRegistered | notifierEvents.SubscriptionCreated
+export type NotificationManagerEvents = notifierEvents.ProviderRegistered
+  | notifierEvents.SubscriptionCreated
+  | notifierEvents.FundsWithdrawn
 
 export type NotifierStakeEvents = notifierStakingEvents.Staked | notifierStakingEvents.Unstaked
 

--- a/src/migrations/scripts/20210728154020-notifierWithdraw.ts
+++ b/src/migrations/scripts/20210728154020-notifierWithdraw.ts
@@ -1,0 +1,11 @@
+import Sequelize, { QueryInterface } from 'sequelize'
+
+export default {
+  async up (queryInterface: QueryInterface): Promise<void> {
+    await queryInterface.addColumn('notifier_subscription', 'withdrawableFunds', Sequelize.STRING)
+  },
+
+  async down (queryInterface: QueryInterface): Promise<void> {
+    await queryInterface.removeColumn('notifier_subscription', 'withdrawableFunds')
+  }
+}

--- a/src/services/notifier/handlers/provider.ts
+++ b/src/services/notifier/handlers/provider.ts
@@ -83,10 +83,6 @@ export const handlers = {
     logger.info(`Created new Subscription ${hash} by Consumer ${consumer} for Provider ${provider}`)
   },
   FundsWithdrawn (event: FundsWithdrawn, { subscriptionService }: NotifierServices): void {
-    console.log('****************************************************************');
-    console.log('🐛 -> withdrawn! <- 🐛');
-    console.log('****************************************************************');
-    // TODO: check the need for storing some of this data
     const { provider, hash, amount, token } = event.returnValues
 
     const withdrawnEvent = {
@@ -109,7 +105,7 @@ function isValidEvent (eventName: string): eventName is keyof typeof handlers {
 
 const handler: Handler<NotificationManagerEvents, NotifierServices> = {
   events: ['ProviderRegistered', 'SubscriptionCreated', 'FundsWithdrawn'],
-  process(event: NotificationManagerEvents, services: NotifierServices, { eth }): Promise<void> {
+  process (event: NotificationManagerEvents, services: NotifierServices, { eth }): Promise<void> {
     if (!isValidEvent(event.event)) {
       return Promise.reject(new Error(`Unknown event ${event.event}`))
     }

--- a/src/services/notifier/models/subscription.model.ts
+++ b/src/services/notifier/models/subscription.model.ts
@@ -70,4 +70,7 @@ export default class SubscriptionModel extends Model {
 
   @Column({ allowNull: false })
   signature!: string
+
+  @Column({ ...BigNumberStringType('withdrawableFunds'), allowNull: true })
+  withdrawableFunds!: BigNumber
 }

--- a/src/services/notifier/notifierService/provider.ts
+++ b/src/services/notifier/notifierService/provider.ts
@@ -47,6 +47,7 @@ export type SubscriptionDTO = {
     topics: Array<Topic>
     signature: string
     userAddress: string
+    subscriptionPayments: any[]
 }
 
 export type NotifierResult<T> = {

--- a/src/services/notifier/utils/updaterUtils.ts
+++ b/src/services/notifier/utils/updaterUtils.ts
@@ -11,6 +11,11 @@ import { NotifierSvcProvider, SubscriptionDTO, SubscriptionPlanDTO } from '../no
 
 const logger = loggingFactory('notifier:updaterUtils')
 
+const SUBSCRIPTION_PAYMENT_STATUS = {
+  RECEIVED: 'RECEIVED',
+  WITHDRAWN: 'WITHDRAWN'
+} as const
+
 function deactivateDeletedPlans (currentPlans: Array<PlanModel>, incomingPlans: Array<SubscriptionPlanDTO>): void {
   if (currentPlans && incomingPlans) {
     const deletedPlans: Array<PlanModel> = currentPlans.filter(({
@@ -124,17 +129,15 @@ const findOrCreateSubscription = async (subscriptionDTO: SubscriptionDTO, url: s
     const { status, amount } = curr
     const bnAmount = new BigNumber(amount)
 
-    // TODO: add new type for status
-    if (status === 'RECEIVED') {
+    if (status === SUBSCRIPTION_PAYMENT_STATUS.RECEIVED) {
       acc.paid = acc.paid.plus(bnAmount)
-    } else if (status === 'WHITDRAWN') {
+    } else if (status === SUBSCRIPTION_PAYMENT_STATUS.WITHDRAWN) {
       acc.withdrawn = acc.withdrawn.plus(bnAmount)
     }
     return acc
   }, balance)
 
   const withdrawableFunds = balance.paid.minus(balance.withdrawn)
-
   const found = await SubscriptionModel.findOne({ where: { hash } })
 
   if (found) {

--- a/src/services/notifier/utils/updaterUtils.ts
+++ b/src/services/notifier/utils/updaterUtils.ts
@@ -106,12 +106,40 @@ export const buildSubscriptionFromDTO = async (subscriptionDTO: SubscriptionDTO,
 }
 
 const findOrCreateSubscription = async (subscriptionDTO: SubscriptionDTO, url: string) => {
-  const { hash, status, paid, notificationBalance, expirationDate } = subscriptionDTO
+  const {
+    hash,
+    status,
+    paid,
+    notificationBalance,
+    expirationDate,
+    subscriptionPayments
+  } = subscriptionDTO
+
+  const balance = {
+    paid: new BigNumber(0),
+    withdrawn: new BigNumber(0)
+  }
+
+  subscriptionPayments.reduce((acc, curr) => {
+    const { status, amount } = curr
+    const bnAmount = new BigNumber(amount)
+
+    // TODO: add new type for status
+    if (status === 'RECEIVED') {
+      acc.paid = acc.paid.plus(bnAmount)
+    } else if (status === 'WHITDRAWN') {
+      acc.withdrawn = acc.withdrawn.plus(bnAmount)
+    }
+    return acc
+  }, balance)
+
+  const withdrawableFunds = balance.paid.minus(balance.withdrawn)
+
   const found = await SubscriptionModel.findOne({ where: { hash } })
 
   if (found) {
     return SubscriptionModel.update(
-      { status, paid, notificationBalance, expirationDate },
+      { status, paid, notificationBalance, expirationDate, withdrawableFunds },
       { where: { hash } })
   }
   const providerModel = await ProviderModel.findOne({ where: { url } })
@@ -122,7 +150,7 @@ const findOrCreateSubscription = async (subscriptionDTO: SubscriptionDTO, url: s
   }
 
   const subscription = await buildSubscriptionFromDTO(subscriptionDTO, provider)
-  return SubscriptionModel.create(subscription)
+  return SubscriptionModel.create({ ...subscription, withdrawableFunds })
 }
 
 export const updateSubscriptionsBy = async (


### PR DESCRIPTION
## Features
- Listen and emits subscription funds withdrawn event
- Calculates and stores new column `withdrawableFunds` for each subscription when fetching data from notifier service (adds new migration)

## Known issues
As discussed, we could set `withdrawableFunds` to `BigNumber(0)` when withdraw event happens. The fact is that then it will get overwritten with notifier provider service data when fetching subscriptions. So, I'm not sure if it makes sense to add that operation, in any case, we can remove the last commit from this PR.

Related to [RMKT-839](https://rsklabs.atlassian.net/jira/software/projects/RMKT/boards/60?selectedIssue=RMKT-839)