### PR TITLE
fix(devops): removes scripts copy to avoid build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ COPY --from=compiler /usr/src/app/node_modules ./node_modules/
 COPY package*.json ./
 COPY bin ./bin/
 COPY config ./config/
-COPY scripts ./scripts/
 
 RUN sed -i 's#"./src/cli"#"./lib/cli"#g' package.json
 


### PR DESCRIPTION
* As "scripts" file doesn't exists,  we must erase this line, because it's producing building failures. 