### PR TITLE
fix(notifier): avoids type error in catch

### DIFF
--- a/src/services/notifier/update.ts
+++ b/src/services/notifier/update.ts
@@ -141,7 +141,7 @@ export async function updateProvider (provider: ProviderModel, sequelize: Sequel
       }
     })
   } catch (error) {
-    logger.error(error)
+    logger.error('Something happened during the plans update:', error)
   }
 }
 


### PR DESCRIPTION
For some reason, CI didn't report this error, but in-box build failed as a result of it.