### PR TITLE
fix(devops): removes only production ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache build-base git python
 
 WORKDIR /usr/src/app
 COPY package*.json ./
-RUN npm ci --only=production && npm i typescript
+RUN npm ci
 COPY . ./
 RUN npx tsc --declaration --declarationDir types
 


### PR DESCRIPTION
The build in testnet keeps failing due to type errors. These errors appear as a result of not installing the typing dependencies, which only exist in the devDependencies. 